### PR TITLE
fix: env.reset makes a transition to DFAs

### DIFF
--- a/temprl/automata.py
+++ b/temprl/automata.py
@@ -58,10 +58,11 @@ class AbstractRewardMachineSimulator(ABC):
     """Interface for abstract reward machine simulator."""
 
     @abstractmethod
-    def reset(self) -> State:
+    def reset(self, initial_obs: Interpretation) -> State:
         """
         Reset the simulation to its initial state.
 
+        :param initial_obs: the fluents in the initial state.
         :return: the initial state.
         """
 
@@ -177,14 +178,17 @@ class RewardDFASimulator(AbstractRewardMachineSimulator):
         self.reward_machine = dfa
         self._current_state: Optional[State] = self.reward_machine.initial_state
 
-    def reset(self) -> State:
+    def reset(self, initial_obs: Interpretation) -> State:
         """
         Reset the simulation to its initial state.
 
+        :param initial_obs: the fluents in the initial state.
         :return: the initial state.
         """
         self._current_state = self.reward_machine.initial_state
-        return self._current_state
+        next_state, _reward = self.step(initial_obs)
+        self._current_state = next_state
+        return next_state
 
     def step(self, symbol: Interpretation) -> Tuple[State, float]:
         """

--- a/temprl/types.py
+++ b/temprl/types.py
@@ -21,11 +21,11 @@
 #
 
 """This module contains the definition of custom types."""
-from typing import AbstractSet, Any, Callable, Hashable
+from typing import AbstractSet, Any, Callable, Hashable, Optional
 
 Interpretation = AbstractSet[Hashable]
 Observation = Any
 Action = Any
-FluentExtractor = Callable[[Observation, Action], Interpretation]
+FluentExtractor = Callable[[Observation, Optional[Action]], Interpretation]
 
 State = Any

--- a/temprl/wrapper.py
+++ b/temprl/wrapper.py
@@ -72,9 +72,14 @@ class TemporalGoal(ABC):
         """Get the reward."""
         return self._reward
 
-    def reset(self) -> State:
-        """Reset the simulator."""
-        return self._simulator.reset()
+    def reset(self, initial_obs: Interpretation) -> State:
+        """
+        Reset the simulator.
+
+        :param initial_obs: the fluents in the initial state.
+        :return: the temporal goal state.
+        """
+        return self._simulator.reset(initial_obs)
 
     def step(self, symbol: Interpretation) -> Tuple[State, float]:
         """
@@ -128,8 +133,6 @@ class TemporalGoalWrapper(gym.Wrapper):
     def reset(self, **_kwargs):
         """Reset the Gym environment."""
         obs = super().reset()
-        for tg in self.temp_goals:
-            tg.reset()
-
-        automata_states = [tg.reset() for tg in self.temp_goals]
+        fluents = self.fluent_extractor(obs, None)
+        automata_states = [tg.reset(fluents) for tg in self.temp_goals]
         return obs, automata_states


### PR DESCRIPTION
## Proposed changes

fix: env.reset makes a transition to DFAs.

The reason is because the evaluation of the temporal goal must be evaluated also after the 'reset' of the environment.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a